### PR TITLE
feat(backend): Seat 도메인 및 좌석 관리 API 구현

### DIFF
--- a/backend/src/main/java/com/concerthub/domain/seat/controller/SeatController.java
+++ b/backend/src/main/java/com/concerthub/domain/seat/controller/SeatController.java
@@ -1,0 +1,109 @@
+package com.concerthub.domain.seat.controller;
+
+import com.concerthub.domain.seat.dto.request.SeatCreateRequest;
+import com.concerthub.domain.seat.dto.response.SeatResponse;
+import com.concerthub.domain.seat.dto.response.SeatSummaryResponse;
+import com.concerthub.domain.seat.entity.Seat;
+import com.concerthub.domain.seat.service.SeatService;
+import com.concerthub.global.response.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+import java.util.Map;
+import java.util.stream.Collectors;
+
+@RestController
+@RequestMapping("/api/events/{eventId}/seats")
+@RequiredArgsConstructor
+public class SeatController {
+
+    private final SeatService seatService;
+
+    @PostMapping
+    @ResponseStatus(HttpStatus.CREATED)
+    public ApiResponse<List<SeatResponse>> createSeats(
+            @PathVariable Long eventId,
+            @Valid @RequestBody SeatCreateRequest request) {
+
+        List<Seat> seats = seatService.createSeats(
+                eventId,
+                request.getTotalRows(),
+                request.getSeatsPerRow(),
+                request.getBasePrice()
+        );
+
+        List<SeatResponse> responses = seats.stream()
+                .map(SeatResponse::from)
+                .collect(Collectors.toList());
+
+        return ApiResponse.success(responses,
+                String.format("총 %d개의 좌석이 생성되었습니다.", seats.size()));
+    }
+
+    @GetMapping
+    public ApiResponse<List<SeatResponse>> getEventSeats(@PathVariable Long eventId) {
+        List<Seat> seats = seatService.getEventSeats(eventId);
+        List<SeatResponse> responses = seats.stream()
+                .map(SeatResponse::from)
+                .collect(Collectors.toList());
+
+        return ApiResponse.success(responses);
+    }
+
+    @GetMapping("/available")
+    public ApiResponse<List<SeatResponse>> getAvailableSeats(@PathVariable Long eventId) {
+        List<Seat> seats = seatService.getAvailableSeats(eventId);
+        List<SeatResponse> responses = seats.stream()
+                .map(SeatResponse::from)
+                .collect(Collectors.toList());
+
+        return ApiResponse.success(responses);
+    }
+
+    @GetMapping("/summary")
+    public ApiResponse<SeatSummaryResponse> getSeatSummary(@PathVariable Long eventId) {
+        List<Seat> seats = seatService.getEventSeats(eventId);
+
+        Map<String, Integer> seatCounts = seats.stream()
+                .collect(Collectors.groupingBy(
+                        seat -> seat.getStatus().name(),
+                        Collectors.collectingAndThen(Collectors.counting(), Math::toIntExact)
+                ));
+
+        Integer minPrice = seats.stream().mapToInt(Seat::getPrice).min().orElse(0);
+        Integer maxPrice = seats.stream().mapToInt(Seat::getPrice).max().orElse(0);
+
+        SeatSummaryResponse summary = SeatSummaryResponse.of(eventId, seatCounts, minPrice, maxPrice);
+        return ApiResponse.success(summary);
+    }
+
+    @PostMapping("/{seatId}/temporary-reserve")
+    public ApiResponse<SeatResponse> temporaryReserveSeat(
+            @PathVariable Long eventId,
+            @PathVariable Long seatId) {
+
+        Seat seat = seatService.temporaryReserveSeat(seatId);
+        return ApiResponse.success(SeatResponse.from(seat), "좌석이 임시 예약되었습니다.");
+    }
+
+    @PostMapping("/{seatId}/confirm")
+    public ApiResponse<SeatResponse> confirmReservation(
+            @PathVariable Long eventId,
+            @PathVariable Long seatId) {
+
+        Seat seat = seatService.confirmReservation(seatId);
+        return ApiResponse.success(SeatResponse.from(seat), "좌석 예약이 확정되었습니다.");
+    }
+
+    @DeleteMapping("/{seatId}/cancel")
+    public ApiResponse<SeatResponse> cancelReservation(
+            @PathVariable Long eventId,
+            @PathVariable Long seatId) {
+
+        Seat seat = seatService.cancelReservation(seatId);
+        return ApiResponse.success(SeatResponse.from(seat), "좌석 예약이 취소되었습니다.");
+    }
+}

--- a/backend/src/main/java/com/concerthub/domain/seat/dto/request/SeatCreateRequest.java
+++ b/backend/src/main/java/com/concerthub/domain/seat/dto/request/SeatCreateRequest.java
@@ -1,0 +1,24 @@
+package com.concerthub.domain.seat.dto.request;
+
+import jakarta.validation.constraints.*;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class SeatCreateRequest {
+
+    @NotNull(message = "총 행 수는 필수입니다.")
+    @Min(value = 1, message = "총 행 수는 1 이상이어야 합니다.")
+    @Max(value = 50, message = "총 행 수는 50을 초과할 수 없습니다.")
+    private Integer totalRows;
+
+    @NotNull(message = "행당 좌석 수는 필수입니다.")
+    @Min(value = 1, message = "행당 좌석 수는 1 이상이어야 합니다.")
+    @Max(value = 100, message = "행당 좌석 수는 100을 초과할 수 없습니다.")
+    private Integer seatsPerRow;
+
+    @NotNull(message = "기본 가격은 필수입니다.")
+    @Min(value = 0, message = "기본 가격은 0 이상이어야 합니다.")
+    private Integer basePrice;
+}

--- a/backend/src/main/java/com/concerthub/domain/seat/dto/response/SeatResponse.java
+++ b/backend/src/main/java/com/concerthub/domain/seat/dto/response/SeatResponse.java
@@ -1,0 +1,41 @@
+package com.concerthub.domain.seat.dto.response;
+
+import com.concerthub.domain.seat.entity.Seat;
+import com.concerthub.domain.seat.entity.status.SeatStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class SeatResponse {
+
+    private Long id;
+    private Long eventId;
+    private String seatRow;
+    private String seatNumber;
+    private String seatDisplay;
+    private Integer price;
+    private SeatStatus status;
+    private LocalDateTime temporaryReservedAt;
+    private boolean isExpired;
+    private LocalDateTime createdAt;
+    private LocalDateTime updatedAt;
+
+    public static SeatResponse from(Seat seat) {
+        return SeatResponse.builder()
+                .id(seat.getId())
+                .eventId(seat.getEvent().getId())
+                .seatRow(seat.getSeatRow())
+                .seatNumber(seat.getSeatNumber())
+                .seatDisplay(seat.getSeatDisplay())
+                .price(seat.getPrice())
+                .status(seat.getStatus())
+                .temporaryReservedAt(seat.getTemporaryReservedAt())
+                .isExpired(seat.isTemporaryReservationExpired())
+                .createdAt(seat.getCreatedAt())
+                .updatedAt(seat.getUpdatedAt())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/concerthub/domain/seat/dto/response/SeatSummaryResponse.java
+++ b/backend/src/main/java/com/concerthub/domain/seat/dto/response/SeatSummaryResponse.java
@@ -1,0 +1,34 @@
+package com.concerthub.domain.seat.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.Map;
+
+@Getter
+@Builder
+public class SeatSummaryResponse {
+
+    private Long eventId;
+    private Integer totalSeats;
+    private Integer availableSeats;
+    private Integer temporaryReservedSeats;
+    private Integer reservedSeats;
+    private Integer blockedSeats;
+    private Map<String, Integer> priceRange; // min, max 가격
+
+    public static SeatSummaryResponse of(Long eventId,
+                                         Map<String, Integer> seatCounts,
+                                         Integer minPrice,
+                                         Integer maxPrice) {
+        return SeatSummaryResponse.builder()
+                .eventId(eventId)
+                .totalSeats(seatCounts.values().stream().mapToInt(Integer::intValue).sum())
+                .availableSeats(seatCounts.getOrDefault("AVAILABLE", 0))
+                .temporaryReservedSeats(seatCounts.getOrDefault("TEMPORARILY_RESERVED", 0))
+                .reservedSeats(seatCounts.getOrDefault("RESERVED", 0))
+                .blockedSeats(seatCounts.getOrDefault("BLOCKED", 0))
+                .priceRange(Map.of("min", minPrice, "max", maxPrice))
+                .build();
+    }
+}

--- a/backend/src/main/java/com/concerthub/domain/seat/entity/Seat.java
+++ b/backend/src/main/java/com/concerthub/domain/seat/entity/Seat.java
@@ -1,0 +1,103 @@
+package com.concerthub.domain.seat.entity;
+
+import com.concerthub.domain.event.entity.Event;
+import com.concerthub.domain.seat.entity.status.SeatStatus;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "seats",
+        uniqueConstraints = {
+                @UniqueConstraint(columnNames = {"event_id", "seat_row", "seat_number"})
+        })
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@EntityListeners(AuditingEntityListener.class)
+public class Seat {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "event_id", nullable = false)
+    private Event event;
+
+    @Column(nullable = false, length = 5)
+    private String seatRow;      // A, B, C 등
+
+    @Column(nullable = false, length = 10)
+    private String seatNumber;   // 1, 2, 3 등
+
+    @Column(nullable = false)
+    private Integer price;
+
+    @Enumerated(EnumType.STRING)
+    @Column(nullable = false)
+    private SeatStatus status;
+
+    @Column
+    private LocalDateTime temporaryReservedAt; // 임시 예약 시작 시간
+
+    @CreatedDate
+    @Column(nullable = false, updatable = false)
+    private LocalDateTime createdAt;
+
+    @LastModifiedDate
+    @Column(nullable = false)
+    private LocalDateTime updatedAt;
+
+    @Builder
+    public Seat(Event event, String seatRow, String seatNumber, Integer price) {
+        this.event = event;
+        this.seatRow = seatRow;
+        this.seatNumber = seatNumber;
+        this.price = price;
+        this.status = SeatStatus.AVAILABLE;
+    }
+
+    // 비즈니스 로직
+    public void temporaryReserve() {
+        if (this.status != SeatStatus.AVAILABLE) {
+            throw new IllegalStateException("예약 가능한 좌석이 아닙니다.");
+        }
+        this.status = SeatStatus.TEMPORARILY_RESERVED;
+        this.temporaryReservedAt = LocalDateTime.now();
+    }
+
+    public void reserve() {
+        if (this.status != SeatStatus.TEMPORARILY_RESERVED) {
+            throw new IllegalStateException("임시 예약된 좌석만 예약 확정할 수 있습니다.");
+        }
+        this.status = SeatStatus.RESERVED;
+        this.temporaryReservedAt = null;
+    }
+
+    public void cancelReservation() {
+        this.status = SeatStatus.AVAILABLE;
+        this.temporaryReservedAt = null;
+    }
+
+    public boolean isAvailable() {
+        return this.status == SeatStatus.AVAILABLE;
+    }
+
+    public boolean isTemporaryReservationExpired() {
+        if (this.status != SeatStatus.TEMPORARILY_RESERVED || this.temporaryReservedAt == null) {
+            return false;
+        }
+        return LocalDateTime.now().isAfter(this.temporaryReservedAt.plusMinutes(15));
+    }
+
+    public String getSeatDisplay() {
+        return seatRow + "-" + seatNumber;
+    }
+}

--- a/backend/src/main/java/com/concerthub/domain/seat/entity/status/SeatStatus.java
+++ b/backend/src/main/java/com/concerthub/domain/seat/entity/status/SeatStatus.java
@@ -1,0 +1,8 @@
+package com.concerthub.domain.seat.entity.status;
+
+public enum SeatStatus {
+    AVAILABLE,           // 예약 가능
+    TEMPORARILY_RESERVED, // 임시 예약 (15분 TTL)
+    RESERVED,            // 예약 완료
+    BLOCKED              // 좌석 차단 (판매 불가)
+}

--- a/backend/src/main/java/com/concerthub/domain/seat/repository/SeatRepository.java
+++ b/backend/src/main/java/com/concerthub/domain/seat/repository/SeatRepository.java
@@ -1,0 +1,40 @@
+package com.concerthub.domain.seat.repository;
+
+import com.concerthub.domain.seat.entity.Seat;
+import com.concerthub.domain.seat.entity.status.SeatStatus;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+import org.springframework.stereotype.Repository;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+@Repository
+public interface SeatRepository extends JpaRepository<Seat, Long> {
+
+    // 이벤트별 좌석 조회
+    List<Seat> findByEventIdOrderBySeatRowAscSeatNumberAsc(Long eventId);
+
+    // 이벤트별 특정 상태 좌석 조회
+    List<Seat> findByEventIdAndStatus(Long eventId, SeatStatus status);
+
+    // 예약 가능한 좌석만 조회
+    List<Seat> findByEventIdAndStatusOrderBySeatRowAscSeatNumberAsc(Long eventId, SeatStatus status);
+
+    // 특정 좌석 조회 (이벤트ID + 행 + 번호)
+    Optional<Seat> findByEventIdAndSeatRowAndSeatNumber(Long eventId, String seatRow, String seatNumber);
+
+    // 만료된 임시 예약 좌석 조회
+    @Query("SELECT s FROM Seat s WHERE s.status = :status AND s.temporaryReservedAt < :expiredTime")
+    List<Seat> findExpiredTemporaryReservations(@Param("status") SeatStatus status,
+                                                @Param("expiredTime") LocalDateTime expiredTime);
+
+    // 이벤트별 상태별 좌석 수 카운트
+    @Query("SELECT s.status, COUNT(s) FROM Seat s WHERE s.event.id = :eventId GROUP BY s.status")
+    List<Object[]> countSeatsByStatus(@Param("eventId") Long eventId);
+
+    // 특정 행의 좌석들 조회
+    List<Seat> findByEventIdAndSeatRowOrderBySeatNumberAsc(Long eventId, String seatRow);
+}

--- a/backend/src/main/java/com/concerthub/domain/seat/service/SeatService.java
+++ b/backend/src/main/java/com/concerthub/domain/seat/service/SeatService.java
@@ -1,0 +1,129 @@
+package com.concerthub.domain.seat.service;
+
+import com.concerthub.domain.event.entity.Event;
+import com.concerthub.domain.event.service.EventService;
+import com.concerthub.domain.seat.entity.Seat;
+import com.concerthub.domain.seat.entity.status.SeatStatus;
+import com.concerthub.domain.seat.repository.SeatRepository;
+import com.concerthub.global.exception.BusinessException;
+import com.concerthub.global.exception.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.List;
+
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class SeatService {
+
+    private final SeatRepository seatRepository;
+    private final EventService eventService;
+
+    @Transactional
+    public List<Seat> createSeats(Long eventId, int totalRows, int seatsPerRow, Integer basePrice) {
+        Event event = eventService.getEvent(eventId);
+
+        List<Seat> seats = new ArrayList<>();
+
+        for (int row = 1; row <= totalRows; row++) {
+            String seatRow = String.valueOf((char) ('A' + row - 1)); // A, B, C...
+
+            for (int seatNum = 1; seatNum <= seatsPerRow; seatNum++) {
+                // 좌석별 가격 차등 (앞자리 더 비쌈)
+                Integer seatPrice = calculateSeatPrice(basePrice, row, totalRows);
+
+                Seat seat = Seat.builder()
+                        .event(event)
+                        .seatRow(seatRow)
+                        .seatNumber(String.valueOf(seatNum))
+                        .price(seatPrice)
+                        .build();
+
+                seats.add(seat);
+            }
+        }
+
+        return seatRepository.saveAll(seats);
+    }
+
+    public List<Seat> getEventSeats(Long eventId) {
+        eventService.getEvent(eventId); // 이벤트 존재 확인
+        return seatRepository.findByEventIdOrderBySeatRowAscSeatNumberAsc(eventId);
+    }
+
+    public List<Seat> getAvailableSeats(Long eventId) {
+        eventService.getEvent(eventId); // 이벤트 존재 확인
+        return seatRepository.findByEventIdAndStatusOrderBySeatRowAscSeatNumberAsc(eventId, SeatStatus.AVAILABLE);
+    }
+
+    public Seat getSeat(Long seatId) {
+        return seatRepository.findById(seatId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SEAT_NOT_FOUND));
+    }
+
+    public Seat getSeat(Long eventId, String seatRow, String seatNumber) {
+        return seatRepository.findByEventIdAndSeatRowAndSeatNumber(eventId, seatRow, seatNumber)
+                .orElseThrow(() -> new BusinessException(ErrorCode.SEAT_NOT_FOUND));
+    }
+
+    @Transactional
+    public Seat temporaryReserveSeat(Long seatId) {
+        Seat seat = getSeat(seatId);
+
+        try {
+            seat.temporaryReserve();
+        } catch (IllegalStateException e) {
+            throw new BusinessException(ErrorCode.SEAT_NOT_AVAILABLE, e.getMessage());
+        }
+
+        return seat;
+    }
+
+    @Transactional
+    public Seat confirmReservation(Long seatId) {
+        Seat seat = getSeat(seatId);
+
+        try {
+            seat.reserve();
+            seat.getEvent().decreaseAvailableSeats();
+        } catch (IllegalStateException e) {
+            throw new BusinessException(ErrorCode.INVALID_SEAT_OPERATION, e.getMessage());
+        }
+
+        return seat;
+    }
+
+    @Transactional
+    public Seat cancelReservation(Long seatId) {
+        Seat seat = getSeat(seatId);
+
+        boolean wasReserved = seat.getStatus() == SeatStatus.RESERVED;
+        seat.cancelReservation();
+
+        // 확정 예약이었다면 이벤트의 available 좌석 수 증가
+        if (wasReserved) {
+            seat.getEvent().increaseAvailableSeats();
+        }
+
+        return seat;
+    }
+
+    @Transactional
+    public void cleanupExpiredTemporaryReservations() {
+        LocalDateTime expiredTime = LocalDateTime.now().minusMinutes(15);
+        List<Seat> expiredSeats = seatRepository.findExpiredTemporaryReservations(
+                SeatStatus.TEMPORARILY_RESERVED, expiredTime);
+
+        expiredSeats.forEach(Seat::cancelReservation);
+    }
+
+    private Integer calculateSeatPrice(Integer basePrice, int row, int totalRows) {
+        // 앞자리일수록 더 비쌈 (첫 번째 행이 가장 비쌈)
+        double multiplier = 1.0 + (double) (totalRows - row) / totalRows * 0.5;
+        return (int) (basePrice * multiplier);
+    }
+}

--- a/backend/src/main/java/com/concerthub/global/exception/ErrorCode.java
+++ b/backend/src/main/java/com/concerthub/global/exception/ErrorCode.java
@@ -20,9 +20,13 @@ public enum ErrorCode {
     EVENT_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "E003", "예약할 수 없는 이벤트입니다."),
     INVALID_SEAT_COUNT(HttpStatus.BAD_REQUEST, "E004", "좌석 수가 올바르지 않습니다."),
 
-    // 좌석 관련 에러 (추후 사용)
+    // 좌석 관련 에러
     SEAT_NOT_FOUND(HttpStatus.NOT_FOUND, "S001", "존재하지 않는 좌석입니다."),
     SEAT_ALREADY_RESERVED(HttpStatus.BAD_REQUEST, "S002", "이미 예약된 좌석입니다."),
+    SEAT_NOT_AVAILABLE(HttpStatus.BAD_REQUEST, "S003", "예약할 수 없는 좌석입니다."),
+    SEAT_TEMPORARILY_RESERVED(HttpStatus.BAD_REQUEST, "S004", "임시 예약된 좌석입니다."),
+    SEAT_RESERVATION_EXPIRED(HttpStatus.BAD_REQUEST, "S005", "좌석 예약 시간이 만료되었습니다."),
+    INVALID_SEAT_OPERATION(HttpStatus.BAD_REQUEST, "S006", "잘못된 좌석 작업입니다."),
 
     // 예약 관련 에러 (추후 사용)
     RESERVATION_NOT_FOUND(HttpStatus.NOT_FOUND, "R001", "존재하지 않는 예약입니다."),


### PR DESCRIPTION
- Seat 엔티티 및 SeatStatus enum 구현
- Event와 Seat 1:N 관계 설정 
- 좌석 생성 API (대량 생성 지원)
- 좌석 조회 API (전체, 예약가능, 요약)
- 좌석 예약 프로세스 (임시예약 → 확정 → 취소)
- 좌석별 가격 차등 적용 (앞자리 더 비쌈)
- 좌석 상태 관리 및 15분 TTL 체크

API 엔드포인트:
- POST /api/events/{eventId}/seats - 좌석 생성
- GET /api/events/{eventId}/seats - 좌석 목록
- GET /api/events/{eventId}/seats/available - 예약가능 좌석
- GET /api/events/{eventId}/seats/summary - 좌석 요약
- POST /api/events/{eventId}/seats/{seatId}/temporary-reserve - 임시예약
- POST /api/events/{eventId}/seats/{seatId}/confirm - 예약확정
- DELETE /api/events/{eventId}/seats/{seatId}/cancel - 예약취소"