### PR TITLE
feat(backend): 관리자용 예약 현황 조회 API 구현 [Fetch Join]

### DIFF
--- a/backend/src/main/java/com/concerthub/domain/admin/controller/AdminReservationController.java
+++ b/backend/src/main/java/com/concerthub/domain/admin/controller/AdminReservationController.java
@@ -1,0 +1,56 @@
+package com.concerthub.domain.admin.controller;
+
+import com.concerthub.domain.admin.dto.request.ReservationSearchRequest;
+import com.concerthub.domain.admin.dto.response.AdminReservationResponse;
+import com.concerthub.domain.admin.dto.response.ReservationStatsResponse;
+import com.concerthub.domain.admin.service.AdminReservationService;
+import com.concerthub.global.response.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.security.access.prepost.PreAuthorize;
+import org.springframework.web.bind.annotation.*;
+
+@Slf4j
+@RestController
+@RequestMapping("/api/admin/reservations")
+@RequiredArgsConstructor
+@PreAuthorize("hasRole('ADMIN')")
+public class AdminReservationController {
+
+    private final AdminReservationService adminReservationService;
+
+    /**
+     * 전체 예약 내역 조회 (필터링 + 페이지네이션)
+     */
+    @GetMapping
+    public ApiResponse<Page<AdminReservationResponse>> getAllReservations(
+            @ModelAttribute ReservationSearchRequest request) {
+        
+        Page<AdminReservationResponse> reservations = adminReservationService.searchReservations(request);
+        return ApiResponse.onSuccess(reservations);
+    }
+
+    /**
+     * 이벤트별 예약 현황 조회
+     */
+    @GetMapping("/events/{eventId}")
+    public ApiResponse<Page<AdminReservationResponse>> getEventReservations(
+            @PathVariable Long eventId,
+            @RequestParam(defaultValue = "0") int page,
+            @RequestParam(defaultValue = "20") int size) {
+        
+        Page<AdminReservationResponse> reservations = 
+                adminReservationService.getEventReservations(eventId, page, size);
+        return ApiResponse.onSuccess(reservations);
+    }
+
+    /**
+     * 예약 통계 조회
+     */
+    @GetMapping("/stats")
+    public ApiResponse<ReservationStatsResponse> getReservationStats() {
+        ReservationStatsResponse stats = adminReservationService.getReservationStats();
+        return ApiResponse.onSuccess(stats);
+    }
+}

--- a/backend/src/main/java/com/concerthub/domain/admin/dto/request/ReservationSearchRequest.java
+++ b/backend/src/main/java/com/concerthub/domain/admin/dto/request/ReservationSearchRequest.java
@@ -1,0 +1,31 @@
+package com.concerthub.domain.admin.dto.request;
+
+import com.concerthub.domain.reservation.entity.status.ReservationStatus;
+import lombok.Getter;
+import lombok.Setter;
+import org.springframework.format.annotation.DateTimeFormat;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Setter
+public class ReservationSearchRequest {
+
+    private Long eventId;
+    private ReservationStatus status;
+    
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime startDate;
+    
+    @DateTimeFormat(iso = DateTimeFormat.ISO.DATE_TIME)
+    private LocalDateTime endDate;
+    
+    private String userEmail;
+    private String userName;
+    
+    // 페이지네이션
+    private int page = 0;
+    private int size = 20;
+    private String sortBy = "createdAt";
+    private String sortDirection = "desc";
+}

--- a/backend/src/main/java/com/concerthub/domain/admin/dto/response/AdminReservationResponse.java
+++ b/backend/src/main/java/com/concerthub/domain/admin/dto/response/AdminReservationResponse.java
@@ -1,0 +1,59 @@
+package com.concerthub.domain.admin.dto.response;
+
+import com.concerthub.domain.reservation.entity.Reservation;
+import com.concerthub.domain.reservation.entity.status.ReservationStatus;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.time.LocalDateTime;
+
+@Getter
+@Builder
+public class AdminReservationResponse {
+
+    private Long id;
+    private ReservationStatus status;
+    private Integer totalPrice;
+    private String paymentId;
+    private LocalDateTime createdAt;
+    private LocalDateTime expiresAt;
+    
+    // 이벤트 정보
+    private Long eventId;
+    private String eventTitle;
+    private String eventVenue;
+    private LocalDateTime eventDateTime;
+    
+    // 좌석 정보
+    private Long seatId;
+    private String seatDisplay;
+    private Integer seatPrice;
+    
+    // 사용자 정보
+    private Long userId;
+    private String userName;
+    private String userEmail;
+    private String userPhoneNumber;
+
+    public static AdminReservationResponse from(Reservation reservation) {
+        return AdminReservationResponse.builder()
+                .id(reservation.getId())
+                .status(reservation.getStatus())
+                .totalPrice(reservation.getTotalPrice())
+                .paymentId(reservation.getPaymentId())
+                .createdAt(reservation.getCreatedAt())
+                .expiresAt(reservation.getExpiresAt())
+                .eventId(reservation.getEvent().getId())
+                .eventTitle(reservation.getEvent().getTitle())
+                .eventVenue(reservation.getEvent().getVenue())
+                .eventDateTime(reservation.getEvent().getEventDateTime())
+                .seatId(reservation.getSeat().getId())
+                .seatDisplay(reservation.getSeat().getSeatDisplay())
+                .seatPrice(reservation.getSeat().getPrice())
+                .userId(reservation.getUser().getId())
+                .userName(reservation.getUser().getName())
+                .userEmail(reservation.getUser().getEmail())
+                .userPhoneNumber(reservation.getUser().getPhoneNumber())
+                .build();
+    }
+}

--- a/backend/src/main/java/com/concerthub/domain/admin/dto/response/ReservationStatsResponse.java
+++ b/backend/src/main/java/com/concerthub/domain/admin/dto/response/ReservationStatsResponse.java
@@ -1,0 +1,33 @@
+package com.concerthub.domain.admin.dto.response;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import java.math.BigDecimal;
+
+@Getter
+@Builder
+public class ReservationStatsResponse {
+
+    // 예약 수 통계
+    private Long totalReservations;
+    private Long pendingReservations;
+    private Long confirmedReservations;
+    private Long cancelledReservations;
+    private Long expiredReservations;
+    
+    // 매출 통계
+    private BigDecimal totalRevenue;
+    private BigDecimal confirmedRevenue;
+    private BigDecimal pendingRevenue;
+    
+    // 기간별 통계
+    private Long todayReservations;
+    private Long thisWeekReservations;
+    private Long thisMonthReservations;
+    
+    // 매출 기간별 통계
+    private BigDecimal todayRevenue;
+    private BigDecimal thisWeekRevenue;
+    private BigDecimal thisMonthRevenue;
+}

--- a/backend/src/main/java/com/concerthub/domain/admin/service/AdminReservationService.java
+++ b/backend/src/main/java/com/concerthub/domain/admin/service/AdminReservationService.java
@@ -1,0 +1,131 @@
+package com.concerthub.domain.admin.service;
+
+import com.concerthub.domain.admin.dto.request.ReservationSearchRequest;
+import com.concerthub.domain.admin.dto.response.AdminReservationResponse;
+import com.concerthub.domain.admin.dto.response.ReservationStatsResponse;
+import com.concerthub.domain.reservation.entity.Reservation;
+import com.concerthub.domain.reservation.entity.status.ReservationStatus;
+import com.concerthub.domain.reservation.repository.ReservationRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.domain.Sort;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class AdminReservationService {
+
+    private final ReservationRepository reservationRepository;
+
+    /**
+     * 관리자용 예약 검색 (필터링 + 페이지네이션)
+     */
+    public Page<AdminReservationResponse> searchReservations(ReservationSearchRequest request) {
+        // 정렬 설정
+        Sort.Direction direction = "desc".equalsIgnoreCase(request.getSortDirection()) 
+            ? Sort.Direction.DESC : Sort.Direction.ASC;
+        Sort sort = Sort.by(direction, request.getSortBy());
+        Pageable pageable = PageRequest.of(request.getPage(), request.getSize(), sort);
+
+        // 검색 실행
+        Page<Reservation> reservationPage = reservationRepository.findReservationsWithFilters(
+                request.getEventId(),
+                request.getStatus(),
+                request.getStartDate(),
+                request.getEndDate(),
+                request.getUserEmail(),
+                request.getUserName(),
+                pageable
+        );
+
+        // DTO 변환
+        return reservationPage.map(AdminReservationResponse::from);
+    }
+
+    /**
+     * 이벤트별 예약 현황 조회
+     */
+    public Page<AdminReservationResponse> getEventReservations(Long eventId, int page, int size) {
+        Pageable pageable = PageRequest.of(page, size, Sort.by(Sort.Direction.DESC, "createdAt"));
+        Page<Reservation> reservationPage = reservationRepository.findByEventIdWithDetails(eventId, pageable);
+        return reservationPage.map(AdminReservationResponse::from);
+    }
+
+    /**
+     * 예약 통계 조회
+     */
+    public ReservationStatsResponse getReservationStats() {
+        // 상태별 예약 수 통계
+        Map<ReservationStatus, Long> reservationCounts = getReservationCountsByStatus();
+        
+        // 상태별 매출 통계
+        Map<ReservationStatus, BigDecimal> revenueByStatus = getRevenueByStatus();
+        
+        // 기간별 통계
+        LocalDateTime now = LocalDateTime.now();
+        LocalDateTime todayStart = now.with(LocalTime.MIN);
+        LocalDateTime weekStart = now.minusDays(7);
+        LocalDateTime monthStart = now.minusMonths(1);
+
+        return ReservationStatsResponse.builder()
+                // 예약 수 통계
+                .totalReservations(reservationCounts.values().stream().mapToLong(Long::longValue).sum())
+                .pendingReservations(reservationCounts.getOrDefault(ReservationStatus.PENDING, 0L))
+                .confirmedReservations(reservationCounts.getOrDefault(ReservationStatus.CONFIRMED, 0L))
+                .cancelledReservations(reservationCounts.getOrDefault(ReservationStatus.CANCELLED, 0L))
+                .expiredReservations(reservationCounts.getOrDefault(ReservationStatus.EXPIRED, 0L))
+                // 매출 통계
+                .totalRevenue(revenueByStatus.values().stream()
+                        .reduce(BigDecimal.ZERO, BigDecimal::add))
+                .confirmedRevenue(revenueByStatus.getOrDefault(ReservationStatus.CONFIRMED, BigDecimal.ZERO))
+                .pendingRevenue(revenueByStatus.getOrDefault(ReservationStatus.PENDING, BigDecimal.ZERO))
+                // 기간별 예약 수
+                .todayReservations(reservationRepository.countReservationsByDateRange(todayStart, now))
+                .thisWeekReservations(reservationRepository.countReservationsByDateRange(weekStart, now))
+                .thisMonthReservations(reservationRepository.countReservationsByDateRange(monthStart, now))
+                // 기간별 매출
+                .todayRevenue(reservationRepository.sumConfirmedRevenueByDateRange(todayStart, now))
+                .thisWeekRevenue(reservationRepository.sumConfirmedRevenueByDateRange(weekStart, now))
+                .thisMonthRevenue(reservationRepository.sumConfirmedRevenueByDateRange(monthStart, now))
+                .build();
+    }
+
+    private Map<ReservationStatus, Long> getReservationCountsByStatus() {
+        List<Object[]> results = reservationRepository.countReservationsByStatus();
+        Map<ReservationStatus, Long> counts = new HashMap<>();
+        
+        for (Object[] result : results) {
+            ReservationStatus status = (ReservationStatus) result[0];
+            Long count = (Long) result[1];
+            counts.put(status, count);
+        }
+        
+        return counts;
+    }
+
+    private Map<ReservationStatus, BigDecimal> getRevenueByStatus() {
+        List<Object[]> results = reservationRepository.sumRevenueByStatus();
+        Map<ReservationStatus, BigDecimal> revenue = new HashMap<>();
+        
+        for (Object[] result : results) {
+            ReservationStatus status = (ReservationStatus) result[0];
+            BigDecimal amount = (BigDecimal) result[1];
+            revenue.put(status, amount != null ? amount : BigDecimal.ZERO);
+        }
+        
+        return revenue;
+    }
+}

--- a/backend/src/main/java/com/concerthub/domain/reservation/repository/ReservationRepository.java
+++ b/backend/src/main/java/com/concerthub/domain/reservation/repository/ReservationRepository.java
@@ -3,12 +3,15 @@ package com.concerthub.domain.reservation.repository;
 import com.concerthub.domain.reservation.entity.Reservation;
 import com.concerthub.domain.reservation.entity.status.ReservationStatus;
 import jakarta.persistence.LockModeType;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.jpa.repository.Lock;
 import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.repository.query.Param;
 import org.springframework.stereotype.Repository;
 
+import java.math.BigDecimal;
 import java.time.LocalDateTime;
 import java.util.List;
 import java.util.Optional;
@@ -40,4 +43,48 @@ public interface ReservationRepository extends JpaRepository<Reservation, Long> 
     // 이벤트별 예약 수 카운트
     @Query("SELECT COUNT(r) FROM Reservation r WHERE r.event.id = :eventId AND r.status = :status")
     Long countByEventIdAndStatus(@Param("eventId") Long eventId, @Param("status") ReservationStatus status);
+
+    // 관리자용 예약 검색 (복합 조건)
+    @Query("SELECT r FROM Reservation r " +
+           "JOIN FETCH r.event e " +
+           "JOIN FETCH r.seat s " +
+           "JOIN FETCH r.user u " +
+           "WHERE (:eventId IS NULL OR r.event.id = :eventId) " +
+           "AND (:status IS NULL OR r.status = :status) " +
+           "AND (:startDate IS NULL OR r.createdAt >= :startDate) " +
+           "AND (:endDate IS NULL OR r.createdAt <= :endDate) " +
+           "AND (:userEmail IS NULL OR LOWER(u.email) LIKE LOWER(CONCAT('%', :userEmail, '%'))) " +
+           "AND (:userName IS NULL OR LOWER(u.name) LIKE LOWER(CONCAT('%', :userName, '%')))")
+    Page<Reservation> findReservationsWithFilters(
+            @Param("eventId") Long eventId,
+            @Param("status") ReservationStatus status,
+            @Param("startDate") LocalDateTime startDate,
+            @Param("endDate") LocalDateTime endDate,
+            @Param("userEmail") String userEmail,
+            @Param("userName") String userName,
+            Pageable pageable);
+
+    // 예약 통계 - 상태별 개수
+    @Query("SELECT r.status, COUNT(r) FROM Reservation r GROUP BY r.status")
+    List<Object[]> countReservationsByStatus();
+
+    // 예약 통계 - 상태별 매출
+    @Query("SELECT r.status, COALESCE(SUM(CAST(r.totalPrice AS java.math.BigDecimal)), 0) FROM Reservation r GROUP BY r.status")
+    List<Object[]> sumRevenueByStatus();
+
+    // 기간별 예약 통계
+    @Query("SELECT COUNT(r) FROM Reservation r WHERE r.createdAt >= :startDate AND r.createdAt < :endDate")
+    Long countReservationsByDateRange(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    // 기간별 매출 통계
+    @Query("SELECT COALESCE(SUM(CAST(r.totalPrice AS java.math.BigDecimal)), 0) FROM Reservation r " +
+           "WHERE r.status = 'CONFIRMED' AND r.createdAt >= :startDate AND r.createdAt < :endDate")
+    BigDecimal sumConfirmedRevenueByDateRange(@Param("startDate") LocalDateTime startDate, @Param("endDate") LocalDateTime endDate);
+
+    // 이벤트별 예약 현황 (페이지네이션)
+    @Query("SELECT r FROM Reservation r " +
+           "JOIN FETCH r.seat s " +
+           "JOIN FETCH r.user u " +
+           "WHERE r.event.id = :eventId")
+    Page<Reservation> findByEventIdWithDetails(@Param("eventId") Long eventId, Pageable pageable);
 }


### PR DESCRIPTION
## 구현 배경
관리자가 전체 예약 현황을 효율적으로 모니터링하고 관리할 수 있는 시스템이 필요했습니다. 기존에는 개별 예약 조회만 가능했지만, 비즈니스 운영을 위해서는 통계 정보와 필터링 기능이 필수적이었습니다.

## 주요 구현 사항

### 1. 복합 조건 검색 기능
- 이벤트별, 상태별, 기간별, 사용자별 다중 필터링
- JOIN FETCH를 활용한 N+1 문제 해결
- 페이지네이션 지원으로 대용량 데이터 처리 최적화

### 2. 실시간 예약 통계
- 상태별 예약 수 집계 (PENDING/CONFIRMED/CANCELLED/EXPIRED)
- 기간별 매출 통계 (오늘/주간/월간)
- COALESCE와 CAST를 활용한 안전한 매출 계산

### 3. 권한 기반 접근 제어
- @PreAuthorize("hasRole('ADMIN')") 컨트롤러 레벨 권한 제어
- 관리자만 전체 예약 데이터 접근 가능

## 기술적 구현 상세

### Repository 쿼리 최적화
```sql
-- 복합 조건 검색 (JOIN FETCH로 N+1 해결)
SELECT r FROM Reservation r 
JOIN FETCH r.event e 
JOIN FETCH r.seat s 
JOIN FETCH r.user u 
WHERE (:eventId IS NULL OR r.event.id = :eventId)
AND (:status IS NULL OR r.status = :status)
```

### 통계 집계 쿼리
```sql
-- 매출 통계 (BigDecimal 안전 처리)
SELECT COALESCE(SUM(CAST(r.totalPrice AS java.math.BigDecimal)), 0) 
FROM Reservation r 
WHERE r.status = 'CONFIRMED'
```

### API 엔드포인트
- `GET /api/admin/reservations` - 전체 예약 조회 (필터링/페이징)
- `GET /api/admin/reservations/events/{eventId}` - 이벤트별 예약 현황
- `GET /api/admin/reservations/stats` - 예약 통계 정보

## 성능 최적화
- JOIN FETCH를 통한 연관 엔티티 일괄 로딩
- 페이지네이션으로 메모리 사용량 제한
- 인덱스 활용을 위한 WHERE 조건 최적화

## 확장성 고려사항
- 필터 조건 추가 시 쉽게 확장 가능한 구조
- 통계 항목 추가 용이
- 권한 레벨 세분화 가능한 설계

## 테스트 결과
- 관리자 권한 제어 정상 작동
- 복합 필터링 기능 검증 완료
- 페이지네이션 성능 확인
- 통계 집계 정확성 검증

## 향후 개선 방안
- 캐싱 적용으로 통계 조회 성능 향상
- 엑셀 다운로드 기능 추가
- 실시간 대시보드 연동