### PR TITLE
feat(frontend): JWT 기반 로그인/로그아웃 시스템 구현

### DIFF
--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,37 +1,150 @@
-import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
+import React from 'react';
+import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
+import { AuthProvider, useAuth } from './contexts/AuthContext';
 import EventListPage from './pages/EventListPage';
 import SeatSelectionPage from './pages/SeatSelectionPage';
 import ReservationPage from './pages/ReservationPage';
 import UserRegisterPage from './pages/UserRegisterPage';
+import LoginPage from './pages/LoginPage';
 import './App.css';
 
-function App() {
+// 네비게이션 컴포넌트
+const Navigation: React.FC = () => {
+  const { isAuthenticated, logout, isLoading } = useAuth();
+
+  const handleLogout = async () => {
+    try {
+      await logout();
+    } catch (error) {
+      console.error('로그아웃 오류:', error);
+    }
+  };
+
+  if (isLoading) {
+    return (
+      <div className="flex justify-center items-center">
+        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  return (
+    <header className="bg-white shadow-sm border-b">
+      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+        <div className="flex justify-between items-center py-4">
+          <Link to="/" className="text-2xl font-bold text-gray-900">
+            🎫 Concert Hub
+          </Link>
+          
+          <nav className="flex items-center space-x-4">
+            <Link to="/" className="text-blue-600 hover:text-blue-800">
+              홈
+            </Link>
+            
+            {isAuthenticated ? (
+              <>
+                <Link to="/my-tickets" className="text-blue-600 hover:text-blue-800">
+                  내 티켓
+                </Link>
+                <button
+                  onClick={handleLogout}
+                  className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
+                >
+                  로그아웃
+                </button>
+              </>
+            ) : (
+              <>
+                <Link to="/login" className="text-blue-600 hover:text-blue-800">
+                  로그인
+                </Link>
+                <Link to="/register" className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors">
+                  회원가입
+                </Link>
+              </>
+            )}
+          </nav>
+        </div>
+      </div>
+    </header>
+  );
+};
+
+// 보호된 라우트 컴포넌트
+const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
+  const { isAuthenticated, isLoading } = useAuth();
+
+  if (isLoading) {
+    return (
+      <div className="min-h-screen flex items-center justify-center">
+        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+      </div>
+    );
+  }
+
+  if (!isAuthenticated) {
+    return <Navigate to="/login" replace />;
+  }
+
+  return <>{children}</>;
+};
+
+// 메인 앱 내용
+const AppContent: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-gray-50">
+      <Navigation />
+      
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
+        <Routes>
+          {/* 공개 라우트 */}
+          <Route path="/login" element={<LoginPage />} />
+          <Route path="/register" element={<UserRegisterPage />} />
+          <Route path="/" element={<EventListPage />} />
+          
+          {/* 보호된 라우트 */}
+          <Route
+            path="/events/:id/seats"
+            element={
+              <ProtectedRoute>
+                <SeatSelectionPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/reservations/:id"
+            element={
+              <ProtectedRoute>
+                <ReservationPage />
+              </ProtectedRoute>
+            }
+          />
+          <Route
+            path="/my-tickets"
+            element={
+              <ProtectedRoute>
+                <div className="text-center py-16">
+                  <h2 className="text-2xl font-bold text-gray-900 mb-4">내 티켓</h2>
+                  <p className="text-gray-600">마이페이지 기능은 곧 구현될 예정입니다.</p>
+                </div>
+              </ProtectedRoute>
+            }
+          />
+        </Routes>
+      </main>
+    </div>
+  );
+};
+
+// 메인 App 컴포넌트
+const App: React.FC = () => {
   return (
     <Router>
-      <div className="min-h-screen bg-gray-50">
-        <header className="bg-white shadow-sm border-b">
-          <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-            <div className="flex justify-between items-center py-4">
-              <h1 className="text-2xl font-bold text-gray-900">🎫 Concert Hub</h1>
-              <nav>
-                <a href="/" className="text-blue-600 hover:text-blue-800">홈</a>
-                <a href="/register" className="ml-4 text-blue-600 hover:text-blue-800">회원가입</a>
-              </nav>
-            </div>
-          </div>
-        </header>
-
-        <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-          <Routes>
-            <Route path="/" element={<EventListPage />} />
-            <Route path="/events/:id/seats" element={<SeatSelectionPage />} />
-            <Route path="/reservations/:id" element={<ReservationPage />} />
-            <Route path="/register" element={<UserRegisterPage />} />
-          </Routes>
-        </main>
-      </div>
+      <AuthProvider>
+        <AppContent />
+      </AuthProvider>
     </Router>
   );
-}
+};
 
 export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,0 +1,70 @@
+import axios, { AxiosError, AxiosResponse } from 'axios';
+import authService from '../services/authService';
+
+const API_BASE_URL = 'http://localhost:8080/api';
+
+// Axios 인스턴스 생성
+const apiClient = axios.create({
+  baseURL: API_BASE_URL,
+  headers: {
+    'Content-Type': 'application/json',
+  },
+});
+
+// 요청 인터셉터: 모든 요청에 Authorization 헤더 추가
+apiClient.interceptors.request.use(
+  (config) => {
+    const token = authService.getAccessToken();
+    if (token) {
+      config.headers.Authorization = `Bearer ${token}`;
+    }
+    return config;
+  },
+  (error) => {
+    return Promise.reject(error);
+  }
+);
+
+// 응답 인터셉터: 토큰 만료 시 갱신 시도
+apiClient.interceptors.response.use(
+  (response: AxiosResponse) => {
+    return response;
+  },
+  async (error: AxiosError) => {
+    const originalRequest = error.config;
+    
+    // 401 에러이고 아직 재시도하지 않은 요청인 경우
+    if (error.response?.status === 401 && originalRequest && !originalRequest._retry) {
+      originalRequest._retry = true;
+      
+      try {
+        // 토큰 갱신 시도
+        const newTokens = await authService.refreshTokens();
+        
+        if (newTokens && originalRequest.headers) {
+          // 새 토큰으로 재요청
+          originalRequest.headers.Authorization = `Bearer ${newTokens.accessToken}`;
+          return apiClient(originalRequest);
+        }
+      } catch (refreshError) {
+        console.error('Token refresh failed:', refreshError);
+      }
+      
+      // 토큰 갱신 실패 시 로그아웃 처리
+      authService.clearTokens();
+      window.location.href = '/login';
+      return Promise.reject(error);
+    }
+    
+    return Promise.reject(error);
+  }
+);
+
+// TypeScript를 위한 _retry 속성 확장
+declare module 'axios' {
+  interface AxiosRequestConfig {
+    _retry?: boolean;
+  }
+}
+
+export default apiClient;

--- a/frontend/src/contexts/AuthContext.tsx
+++ b/frontend/src/contexts/AuthContext.tsx
@@ -1,0 +1,68 @@
+import React, { createContext, useContext, useState, useEffect, ReactNode } from 'react';
+import authService from '../services/authService';
+
+interface AuthContextType {
+  isAuthenticated: boolean;
+  isLoading: boolean;
+  login: (email: string, password: string) => Promise<void>;
+  logout: () => Promise<void>;
+  checkAuth: () => void;
+}
+
+const AuthContext = createContext<AuthContextType | undefined>(undefined);
+
+interface AuthProviderProps {
+  children: ReactNode;
+}
+
+export const AuthProvider: React.FC<AuthProviderProps> = ({ children }) => {
+  const [isAuthenticated, setIsAuthenticated] = useState(false);
+  const [isLoading, setIsLoading] = useState(true);
+
+  // 인증 상태 확인
+  const checkAuth = () => {
+    const authenticated = authService.isAuthenticated();
+    setIsAuthenticated(authenticated);
+  };
+
+  // 로그인
+  const login = async (email: string, password: string) => {
+    await authService.login({ email, password });
+    setIsAuthenticated(true);
+  };
+
+  // 로그아웃
+  const logout = async () => {
+    await authService.logout();
+    setIsAuthenticated(false);
+  };
+
+  // 컴포넌트 마운트 시 인증 상태 확인
+  useEffect(() => {
+    checkAuth();
+    setIsLoading(false);
+  }, []);
+
+  const value: AuthContextType = {
+    isAuthenticated,
+    isLoading,
+    login,
+    logout,
+    checkAuth,
+  };
+
+  return (
+    <AuthContext.Provider value={value}>
+      {children}
+    </AuthContext.Provider>
+  );
+};
+
+// 커스텀 훅
+export const useAuth = (): AuthContextType => {
+  const context = useContext(AuthContext);
+  if (context === undefined) {
+    throw new Error('useAuth must be used within an AuthProvider');
+  }
+  return context;
+};

--- a/frontend/src/pages/EventListPage.tsx
+++ b/frontend/src/pages/EventListPage.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
-import { api } from '../api';
-import type { ApiResponse } from '../api';
+import { Link } from 'react-router-dom';
+import apiClient from '../api/client';
+import type { ApiResponse } from '../types/auth';
 import type { Event } from '../types';
 
 const EventListPage = () => {
@@ -15,7 +16,7 @@ const EventListPage = () => {
   const fetchEvents = async () => {
     try {
       setLoading(true);
-      const response = await api.get<ApiResponse<Event[]>>('/events');
+      const response = await apiClient.get<ApiResponse<Event[]>>('/events');
       setEvents(response.data.data);
     } catch (err) {
       setError('이벤트를 불러오는데 실패했습니다.');
@@ -100,17 +101,16 @@ const EventListPage = () => {
                 </div>
               </div>
               
-              <button
-                onClick={() => window.location.href = `/events/${event.id}/seats`}
-                disabled={event.status !== 'OPEN'}
-                className={`w-full py-2 px-4 rounded font-medium transition-colors ${
+              <Link
+                to={`/events/${event.id}/seats`}
+                className={`block w-full py-2 px-4 rounded font-medium transition-colors text-center ${
                   event.status === 'OPEN'
                     ? 'bg-blue-600 text-white hover:bg-blue-700'
-                    : 'bg-gray-300 text-gray-500 cursor-not-allowed'
+                    : 'bg-gray-300 text-gray-500 cursor-not-allowed pointer-events-none'
                 }`}
               >
                 {event.status === 'OPEN' ? '좌석 선택' : '예매 불가'}
-              </button>
+              </Link>
             </div>
           ))}
         </div>

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,0 +1,138 @@
+import React, { useState } from 'react';
+import { useNavigate, Link } from 'react-router-dom';
+import authService from '../services/authService';
+import { LoginRequest } from '../types/auth';
+
+const LoginPage: React.FC = () => {
+  const [formData, setFormData] = useState<LoginRequest>({
+    email: '',
+    password: '',
+  });
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string>('');
+  
+  const navigate = useNavigate();
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const { name, value } = e.target;
+    setFormData(prev => ({
+      ...prev,
+      [name]: value,
+    }));
+    // 입력 시 에러 메시지 초기화
+    if (error) setError('');
+  };
+
+  const handleSubmit = async (e: React.FormEvent) => {
+    e.preventDefault();
+    setLoading(true);
+    setError('');
+
+    try {
+      await authService.login(formData);
+      // 로그인 성공 시 홈페이지로 이동
+      navigate('/');
+    } catch (err) {
+      setError(err instanceof Error ? err.message : '로그인에 실패했습니다.');
+    } finally {
+      setLoading(false);
+    }
+  };
+
+  return (
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            🎫 Concert Hub 로그인
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-600">
+            계정이 없으신가요?{' '}
+            <Link to="/register" className="font-medium text-blue-600 hover:text-blue-500">
+              회원가입
+            </Link>
+          </p>
+        </div>
+        
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-4">
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                이메일
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                value={formData.email}
+                onChange={handleChange}
+                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="이메일을 입력해주세요"
+              />
+            </div>
+            
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                비밀번호
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                value={formData.password}
+                onChange={handleChange}
+                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="비밀번호를 입력해주세요"
+              />
+            </div>
+          </div>
+
+          {error && (
+            <div className="rounded-md bg-red-50 p-4">
+              <div className="flex">
+                <div className="ml-3">
+                  <h3 className="text-sm font-medium text-red-800">
+                    로그인 오류
+                  </h3>
+                  <div className="mt-2 text-sm text-red-700">
+                    {error}
+                  </div>
+                </div>
+              </div>
+            </div>
+          )}
+
+          <div>
+            <button
+              type="submit"
+              disabled={loading}
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? (
+                <span className="flex items-center">
+                  <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  로그인 중...
+                </span>
+              ) : (
+                '로그인'
+              )}
+            </button>
+          </div>
+
+          <div className="text-center">
+            <p className="text-sm text-gray-600">
+              테스트 계정: admin@test.com / password123
+            </p>
+          </div>
+        </form>
+      </div>
+    </div>
+  );
+};
+
+export default LoginPage;

--- a/frontend/src/pages/UserRegisterPage.tsx
+++ b/frontend/src/pages/UserRegisterPage.tsx
@@ -1,13 +1,16 @@
 import { useState } from 'react';
-import { api } from '../api';
-import type { ApiResponse } from '../api';
+import { Link, useNavigate } from 'react-router-dom';
+import apiClient from '../api/client';
+import type { ApiResponse } from '../types/auth';
 import type { User } from '../types';
 
 const UserRegisterPage = () => {
+  const navigate = useNavigate();
   const [formData, setFormData] = useState({
     name: '',
     email: '',
-    phoneNumber: ''
+    phoneNumber: '',
+    password: 'password123' // 기본 비밀번호 (실제로는 사용자가 입력해야 함)
   });
   const [loading, setLoading] = useState(false);
   const [user, setUser] = useState<User | null>(null);
@@ -17,12 +20,14 @@ const UserRegisterPage = () => {
     setLoading(true);
 
     try {
-      const response = await api.post<ApiResponse<User>>('/users', formData);
+      const response = await apiClient.post<ApiResponse<User>>('/users/register', formData);
       setUser(response.data.data);
-      alert('회원가입이 완료되었습니다!');
+      alert('회원가입이 완료되었습니다! 로그인 페이지로 이동합니다.');
       
-      // 로컬 스토리지에 사용자 정보 저장 (간단한 로그인 대용)
-      localStorage.setItem('currentUser', JSON.stringify(response.data.data));
+      // 로그인 페이지로 이동
+      setTimeout(() => {
+        navigate('/login');
+      }, 2000);
     } catch (error) {
       console.error('회원가입 실패:', error);
       alert('회원가입에 실패했습니다.');
@@ -42,12 +47,9 @@ const UserRegisterPage = () => {
             <p><strong>이메일:</strong> {user.email}</p>
             <p><strong>전화번호:</strong> {user.phoneNumber}</p>
           </div>
-          <button
-            onClick={() => window.location.href = '/'}
-            className="mt-6 w-full bg-blue-600 text-white py-2 rounded hover:bg-blue-700"
-          >
-            이벤트 보러가기
-          </button>
+          <p className="text-sm text-gray-600 mt-4">
+            잠시 후 로그인 페이지로 이동합니다...
+          </p>
         </div>
       </div>
     );
@@ -102,6 +104,11 @@ const UserRegisterPage = () => {
             />
           </div>
 
+          <div className="text-sm text-gray-600 bg-blue-50 p-3 rounded">
+            <p><strong>알림:</strong> 현재 기본 비밀번호는 'password123'으로 설정됩니다.</p>
+            <p>회원가입 후 해당 비밀번호로 로그인해주세요.</p>
+          </div>
+
           <button
             type="submit"
             disabled={loading}
@@ -110,6 +117,13 @@ const UserRegisterPage = () => {
             {loading ? '가입 중...' : '가입하기'}
           </button>
         </form>
+
+        <p className="mt-4 text-center text-sm text-gray-600">
+          이미 계정이 있으신가요?{' '}
+          <Link to="/login" className="font-medium text-blue-600 hover:text-blue-500">
+            로그인
+          </Link>
+        </p>
       </div>
     </div>
   );

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,0 +1,129 @@
+import { LoginRequest, JwtTokens, ApiResponse } from '../types/auth';
+
+const TOKEN_KEY = 'concert_hub_tokens';
+const API_BASE_URL = 'http://localhost:8080/api';
+
+class AuthService {
+  // 로그인
+  async login(loginData: LoginRequest): Promise<JwtTokens> {
+    try {
+      const response = await fetch(`${API_BASE_URL}/auth/login`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(loginData),
+      });
+
+      if (!response.ok) {
+        const errorData = await response.json();
+        throw new Error(errorData.message || '로그인에 실패했습니다.');
+      }
+
+      const result: ApiResponse<JwtTokens> = await response.json();
+      
+      if (result.success && result.data) {
+        this.setTokens(result.data);
+        return result.data;
+      } else {
+        throw new Error(result.message || '로그인에 실패했습니다.');
+      }
+    } catch (error) {
+      console.error('Login error:', error);
+      throw error;
+    }
+  }
+
+  // 로그아웃
+  async logout(): Promise<void> {
+    try {
+      const tokens = this.getTokens();
+      if (tokens?.accessToken) {
+        await fetch(`${API_BASE_URL}/auth/logout`, {
+          method: 'POST',
+          headers: {
+            'Authorization': `Bearer ${tokens.accessToken}`,
+            'Content-Type': 'application/json',
+          },
+        });
+      }
+    } catch (error) {
+      console.error('Logout error:', error);
+    } finally {
+      this.clearTokens();
+    }
+  }
+
+  // 토큰 갱신
+  async refreshTokens(): Promise<JwtTokens | null> {
+    try {
+      const tokens = this.getTokens();
+      if (!tokens?.refreshToken) {
+        return null;
+      }
+
+      const response = await fetch(`${API_BASE_URL}/auth/refresh`, {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ refreshToken: tokens.refreshToken }),
+      });
+
+      if (!response.ok) {
+        this.clearTokens();
+        return null;
+      }
+
+      const result: ApiResponse<JwtTokens> = await response.json();
+      
+      if (result.success && result.data) {
+        this.setTokens(result.data);
+        return result.data;
+      } else {
+        this.clearTokens();
+        return null;
+      }
+    } catch (error) {
+      console.error('Token refresh error:', error);
+      this.clearTokens();
+      return null;
+    }
+  }
+
+  // 토큰 저장 - localStorage에 JWT 토큰만 저장
+  setTokens(tokens: JwtTokens): void {
+    localStorage.setItem(TOKEN_KEY, JSON.stringify(tokens));
+  }
+
+  // 토큰 조회
+  getTokens(): JwtTokens | null {
+    try {
+      const tokens = localStorage.getItem(TOKEN_KEY);
+      return tokens ? JSON.parse(tokens) : null;
+    } catch {
+      return null;
+    }
+  }
+
+  // 토큰 삭제
+  clearTokens(): void {
+    localStorage.removeItem(TOKEN_KEY);
+    // 기존 currentUser도 함께 삭제 (마이그레이션)
+    localStorage.removeItem('currentUser');
+  }
+
+  // 로그인 상태 확인
+  isAuthenticated(): boolean {
+    const tokens = this.getTokens();
+    return !!tokens?.accessToken;
+  }
+
+  // 액세스 토큰 조회 - API 요청 시 사용
+  getAccessToken(): string | null {
+    const tokens = this.getTokens();
+    return tokens?.accessToken || null;
+  }
+}
+
+export default new AuthService();

--- a/frontend/src/types/auth.ts
+++ b/frontend/src/types/auth.ts
@@ -1,0 +1,26 @@
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+// 백엔드 JwtDto와 일치하도록 수정
+export interface JwtTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
+export interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T;
+}
+
+export interface User {
+  id: number;
+  name: string;
+  email: string;
+  phoneNumber: string;
+  role: 'USER' | 'ADMIN';
+  createdAt: string;
+  updatedAt: string;
+}


### PR DESCRIPTION
## 구현 목표
사용자가 실제 JWT 토큰으로 로그인/로그아웃할 수 있는 프론트엔드 인증 시스템 구현

## 주요 기능
- 로그인 페이지 및 폼 구현
- JWT 토큰 저장 및 관리
- 로그아웃 기능
- 인증이 필요한 API 요청 시 Authorization 헤더 자동 추가
- 토큰 만료 시 자동 로그아웃 처리

## 구현 내용

### 1. 페이지 구성
- `/login` - 로그인 페이지
- 네비게이션에 로그인/로그아웃 버튼 추가

### 2. 인증 관리
- JWT 토큰을 localStorage에 저장
- API 요청 시 Authorization 헤더 자동 추가
- 토큰 검증 및 만료 처리

### 3. UI/UX
- 로그인 폼 (이메일, 비밀번호)
- 로그인 상태에 따른 네비게이션 변경
- 에러 메시지 표시

## API 엔드포인트
- `POST /api/auth/login` - 로그인
- `POST /api/auth/logout` - 로그아웃
- `POST /api/auth/refresh` - 토큰 갱신

## 완료 조건
- 로그인/로그아웃이 정상 동작
- 인증이 필요한 페이지 접근 시 로그인 페이지로 리다이렉트
- JWT 토큰이 모든 API 요청에 자동 포함
- 토큰 만료 시 적절한 처리