### PR TITLE
feat(frontend): JWT 기반 로그인/로그아웃 시스템 구현

### DIFF
--- a/backend/src/main/java/com/concerthub/domain/user/dto/request/UserCreateRequest.java
+++ b/backend/src/main/java/com/concerthub/domain/user/dto/request/UserCreateRequest.java
@@ -21,7 +21,7 @@ public class UserCreateRequest {
     private String email;
 
     @NotBlank(message = "전화번호는 필수입니다.")
-    @Pattern(regexp = "^\\d{3}-\\d{4}-\\d{4}$", message = "전화번호는 000-0000-0000 형식이어야 합니다.")
+    @Pattern(regexp = "^\\d{10,11}$", message = "전화번호는 10-11자리 숫자여야 합니다.")
     private String phoneNumber;
 
     @NotBlank(message = "비밀번호는 필수입니다.")

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -1,150 +1,73 @@
 import React from 'react';
-import { BrowserRouter as Router, Routes, Route, Link, Navigate } from 'react-router-dom';
+import { BrowserRouter as Router, Routes, Route, Navigate } from 'react-router-dom';
 import { AuthProvider, useAuth } from './contexts/AuthContext';
+import LandingPage from './pages/LandingPage';
+import LoginPage from './pages/LoginPage';
+import UserRegisterPage from './pages/UserRegisterPage';
 import EventListPage from './pages/EventListPage';
 import SeatSelectionPage from './pages/SeatSelectionPage';
 import ReservationPage from './pages/ReservationPage';
-import UserRegisterPage from './pages/UserRegisterPage';
-import LoginPage from './pages/LoginPage';
 import './App.css';
-
-// 네비게이션 컴포넌트
-const Navigation: React.FC = () => {
-  const { isAuthenticated, logout, isLoading } = useAuth();
-
-  const handleLogout = async () => {
-    try {
-      await logout();
-    } catch (error) {
-      console.error('로그아웃 오류:', error);
-    }
-  };
-
-  if (isLoading) {
-    return (
-      <div className="flex justify-center items-center">
-        <div className="animate-spin rounded-full h-6 w-6 border-b-2 border-blue-600"></div>
-      </div>
-    );
-  }
-
-  return (
-    <header className="bg-white shadow-sm border-b">
-      <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
-        <div className="flex justify-between items-center py-4">
-          <Link to="/" className="text-2xl font-bold text-gray-900">
-            🎫 Concert Hub
-          </Link>
-          
-          <nav className="flex items-center space-x-4">
-            <Link to="/" className="text-blue-600 hover:text-blue-800">
-              홈
-            </Link>
-            
-            {isAuthenticated ? (
-              <>
-                <Link to="/my-tickets" className="text-blue-600 hover:text-blue-800">
-                  내 티켓
-                </Link>
-                <button
-                  onClick={handleLogout}
-                  className="bg-red-500 hover:bg-red-600 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors"
-                >
-                  로그아웃
-                </button>
-              </>
-            ) : (
-              <>
-                <Link to="/login" className="text-blue-600 hover:text-blue-800">
-                  로그인
-                </Link>
-                <Link to="/register" className="bg-blue-500 hover:bg-blue-600 text-white px-4 py-2 rounded-md text-sm font-medium transition-colors">
-                  회원가입
-                </Link>
-              </>
-            )}
-          </nav>
-        </div>
-      </div>
-    </header>
-  );
-};
 
 // 보호된 라우트 컴포넌트
 const ProtectedRoute: React.FC<{ children: React.ReactNode }> = ({ children }) => {
   const { isAuthenticated, isLoading } = useAuth();
-
+  
   if (isLoading) {
     return (
       <div className="min-h-screen flex items-center justify-center">
-        <div className="animate-spin rounded-full h-12 w-12 border-b-2 border-blue-600"></div>
+        <div className="text-lg">로딩 중...</div>
       </div>
     );
   }
-
-  if (!isAuthenticated) {
-    return <Navigate to="/login" replace />;
-  }
-
-  return <>{children}</>;
+  
+  return isAuthenticated ? <>{children}</> : <Navigate to="/login" />;
 };
 
-// 메인 앱 내용
-const AppContent: React.FC = () => {
+function App() {
   return (
-    <div className="min-h-screen bg-gray-50">
-      <Navigation />
-      
-      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-8">
-        <Routes>
-          {/* 공개 라우트 */}
-          <Route path="/login" element={<LoginPage />} />
-          <Route path="/register" element={<UserRegisterPage />} />
-          <Route path="/" element={<EventListPage />} />
-          
-          {/* 보호된 라우트 */}
-          <Route
-            path="/events/:id/seats"
-            element={
-              <ProtectedRoute>
-                <SeatSelectionPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/reservations/:id"
-            element={
-              <ProtectedRoute>
-                <ReservationPage />
-              </ProtectedRoute>
-            }
-          />
-          <Route
-            path="/my-tickets"
-            element={
-              <ProtectedRoute>
-                <div className="text-center py-16">
-                  <h2 className="text-2xl font-bold text-gray-900 mb-4">내 티켓</h2>
-                  <p className="text-gray-600">마이페이지 기능은 곧 구현될 예정입니다.</p>
-                </div>
-              </ProtectedRoute>
-            }
-          />
-        </Routes>
-      </main>
-    </div>
+    <AuthProvider>
+      <Router>
+        <div className="App">
+          <Routes>
+            {/* 공개 라우트 */}
+            <Route path="/" element={<LandingPage />} />
+            <Route path="/login" element={<LoginPage />} />
+            <Route path="/register" element={<UserRegisterPage />} />
+            
+            {/* 보호된 라우트 */}
+            <Route 
+              path="/events" 
+              element={
+                <ProtectedRoute>
+                  <EventListPage />
+                </ProtectedRoute>
+              } 
+            />
+            <Route 
+              path="/events/:eventId/seats" 
+              element={
+                <ProtectedRoute>
+                  <SeatSelectionPage />
+                </ProtectedRoute>
+              } 
+            />
+            <Route 
+              path="/reservations/:reservationId" 
+              element={
+                <ProtectedRoute>
+                  <ReservationPage />
+                </ProtectedRoute>
+              } 
+            />
+            
+            {/* 잘못된 경로는 랜딩페이지로 */}
+            <Route path="*" element={<Navigate to="/" />} />
+          </Routes>
+        </div>
+      </Router>
+    </AuthProvider>
   );
-};
-
-// 메인 App 컴포넌트
-const App: React.FC = () => {
-  return (
-    <Router>
-      <AuthProvider>
-        <AppContent />
-      </AuthProvider>
-    </Router>
-  );
-};
+}
 
 export default App;

--- a/frontend/src/api/client.ts
+++ b/frontend/src/api/client.ts
@@ -1,4 +1,5 @@
-import axios, { AxiosError, AxiosResponse } from 'axios';
+import axios from 'axios';
+import type { AxiosError, AxiosResponse, InternalAxiosRequestConfig } from 'axios';
 import authService from '../services/authService';
 
 const API_BASE_URL = 'http://localhost:8080/api';
@@ -62,7 +63,7 @@ apiClient.interceptors.response.use(
 
 // TypeScript를 위한 _retry 속성 확장
 declare module 'axios' {
-  interface AxiosRequestConfig {
+  interface InternalAxiosRequestConfig {
     _retry?: boolean;
   }
 }

--- a/frontend/src/pages/LandingPage.tsx
+++ b/frontend/src/pages/LandingPage.tsx
@@ -1,0 +1,93 @@
+import React from 'react';
+import { Link } from 'react-router-dom';
+
+const LandingPage: React.FC = () => {
+  return (
+    <div className="min-h-screen bg-gradient-to-br from-blue-50 to-purple-50">
+      {/* 네비게이션 */}
+      <nav className="bg-white shadow-sm">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8">
+          <div className="flex justify-between items-center h-16">
+            <div className="flex items-center">
+              <h1 className="text-2xl font-bold text-gray-900">🎫 Concert Hub</h1>
+            </div>
+            <div className="flex space-x-4">
+              <Link
+                to="/login"
+                className="bg-gray-100 hover:bg-gray-200 text-gray-700 px-3 py-2 rounded-md text-sm font-medium"
+              >
+                로그인
+              </Link>
+              <Link
+                to="/register"
+                className="bg-blue-600 hover:bg-blue-700 text-white px-4 py-2 rounded-md text-sm font-medium"
+              >
+                회원가입
+              </Link>
+            </div>
+          </div>
+        </div>
+      </nav>
+
+      {/* 메인 콘텐츠 */}
+      <main className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 py-16">
+        <div className="text-center">
+          <h1 className="text-5xl font-extrabold text-gray-900 mb-6">
+            당신의 특별한 순간을
+            <span className="block text-blue-600">예약하세요</span>
+          </h1>
+          
+          <p className="text-xl text-gray-600 mb-8 max-w-3xl mx-auto">
+            콘서트, 뮤지컬, 스포츠 경기까지. 
+            실시간 예약 시스템으로 놓치고 싶지 않은 순간들을 확실하게 잡아보세요.
+          </p>
+
+          <div className="flex justify-center mb-16">
+            <Link
+              to="/login"
+              className="bg-blue-600 hover:bg-blue-700 text-white px-8 py-4 rounded-lg text-lg font-semibold shadow-lg transform hover:scale-105 transition-all"
+            >
+              지금 시작하기
+            </Link>
+          </div>
+
+          {/* 특징 소개 */}
+          <div className="grid md:grid-cols-3 gap-8 max-w-4xl mx-auto">
+            <div className="bg-white p-6 rounded-xl shadow-lg">
+              <div className="text-3xl mb-4">⚡</div>
+              <h3 className="text-xl font-semibold mb-2">실시간 예약</h3>
+              <p className="text-gray-600">
+                대기열 시스템으로 공정하고 빠른 티켓 예약을 경험하세요.
+              </p>
+            </div>
+            
+            <div className="bg-white p-6 rounded-xl shadow-lg">
+              <div className="text-3xl mb-4">🔒</div>
+              <h3 className="text-xl font-semibold mb-2">안전한 결제</h3>
+              <p className="text-gray-600">
+                보안이 강화된 결제 시스템으로 안심하고 이용하세요.
+              </p>
+            </div>
+            
+            <div className="bg-white p-6 rounded-xl shadow-lg">
+              <div className="text-3xl mb-4">📱</div>
+              <h3 className="text-xl font-semibold mb-2">간편한 관리</h3>
+              <p className="text-gray-600">
+                예약 내역부터 티켓 관리까지 한 번에 처리하세요.
+              </p>
+            </div>
+          </div>
+        </div>
+      </main>
+
+      {/* 푸터 */}
+      <footer className="bg-gray-900 text-white py-8 mt-16">
+        <div className="max-w-7xl mx-auto px-4 sm:px-6 lg:px-8 text-center">
+          <p>&copy; 2025 Concert Hub. 신입 개발자 포트폴리오 프로젝트.</p>
+        </div>
+      </footer>
+    </div>
+  );
+};
+
+export default LandingPage;

--- a/frontend/src/pages/LoginPage.tsx
+++ b/frontend/src/pages/LoginPage.tsx
@@ -1,7 +1,7 @@
 import React, { useState } from 'react';
 import { useNavigate, Link } from 'react-router-dom';
 import authService from '../services/authService';
-import { LoginRequest } from '../types/auth';
+import type { LoginRequest } from '../types';
 
 const LoginPage: React.FC = () => {
   const [formData, setFormData] = useState<LoginRequest>({
@@ -30,8 +30,8 @@ const LoginPage: React.FC = () => {
 
     try {
       await authService.login(formData);
-      // 로그인 성공 시 홈페이지로 이동
-      navigate('/');
+  // 로그인 성공 시 이벤트 페이지로 이동
+      navigate('/events');
     } catch (err) {
       setError(err instanceof Error ? err.message : '로그인에 실패했습니다.');
     } finally {
@@ -91,14 +91,12 @@ const LoginPage: React.FC = () => {
 
           {error && (
             <div className="rounded-md bg-red-50 p-4">
-              <div className="flex">
-                <div className="ml-3">
-                  <h3 className="text-sm font-medium text-red-800">
-                    로그인 오류
-                  </h3>
-                  <div className="mt-2 text-sm text-red-700">
-                    {error}
-                  </div>
+              <div className="text-center">
+                <h3 className="text-sm font-medium text-red-800">
+                  로그인 오류
+                </h3>
+                <div className="mt-2 text-sm text-red-700">
+                  {error}
                 </div>
               </div>
             </div>
@@ -122,12 +120,6 @@ const LoginPage: React.FC = () => {
                 '로그인'
               )}
             </button>
-          </div>
-
-          <div className="text-center">
-            <p className="text-sm text-gray-600">
-              테스트 계정: admin@test.com / password123
-            </p>
           </div>
         </form>
       </div>

--- a/frontend/src/pages/UserRegisterPage.tsx
+++ b/frontend/src/pages/UserRegisterPage.tsx
@@ -1,7 +1,8 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import apiClient from '../api/client';
-import type { ApiResponse } from '../types/auth';
+import authService from '../services/authService';
+import type { ApiResponse } from '../types';
 import type { User } from '../types';
 
 const UserRegisterPage = () => {
@@ -10,120 +11,217 @@ const UserRegisterPage = () => {
     name: '',
     email: '',
     phoneNumber: '',
-    password: 'password123' // 기본 비밀번호 (실제로는 사용자가 입력해야 함)
+    password: '',
+    confirmPassword: ''
   });
   const [loading, setLoading] = useState(false);
-  const [user, setUser] = useState<User | null>(null);
+  const [error, setError] = useState('');
 
   const handleSubmit = async (e: React.FormEvent) => {
     e.preventDefault();
     setLoading(true);
+    setError('');
+
+    // 비밀번호 형식 검증
+    const passwordRegex = /^(?=.*[a-zA-Z])(?=.*\d)(?=.*[@$!%*?&])[A-Za-z\d@$!%*?&]+$/;
+    if (!passwordRegex.test(formData.password)) {
+      setError('비밀번호는 영문, 숫자, 특수문자(@$!%*?&)를 포함해야 합니다.');
+      setLoading(false);
+      return;
+    }
+
+    if (formData.password.length < 8) {
+      setError('비밀번호는 8자 이상이어야 합니다.');
+      setLoading(false);
+      return;
+    }
+
+    // 비밀번호 확인 검증
+    if (formData.password !== formData.confirmPassword) {
+      setError('비밀번호가 일치하지 않습니다.');
+      setLoading(false);
+      return;
+    }
 
     try {
-      const response = await apiClient.post<ApiResponse<User>>('/users/register', formData);
-      setUser(response.data.data);
-      alert('회원가입이 완료되었습니다! 로그인 페이지로 이동합니다.');
+      const response = await apiClient.post<ApiResponse<User>>('/users/register', {
+        name: formData.name,
+        email: formData.email,
+        phoneNumber: formData.phoneNumber,
+        password: formData.password
+      });
       
-      // 로그인 페이지로 이동
-      setTimeout(() => {
-        navigate('/login');
-      }, 2000);
-    } catch (error) {
-      console.error('회원가입 실패:', error);
-      alert('회원가입에 실패했습니다.');
+      // 회원가입 성공 후 자동 로그인
+      await authService.login({
+        email: formData.email,
+        password: formData.password
+      });
+      
+      // 메인 페이지로 이동
+      navigate('/events');
+      
+    } catch (error: any) {
+      // 에러 메시지 추출
+      if (error.response?.data?.errors && error.response.data.errors.length > 0) {
+        // 유효성 검증 에러 처리
+        const validationErrors = error.response.data.errors;
+        const errorMessages = validationErrors.map((err: any) => err.reason || err.message || err.defaultMessage).join(', ');
+        setError(errorMessages);
+      } else if (error.response?.data?.message) {
+        setError(error.response.data.message);
+      } else if (error.response?.status === 400) {
+        setError('입력 정보를 다시 확인해주세요.');
+      } else if (error.response?.status === 409) {
+        setError('이미 사용 중인 이메일입니다.');
+      } else {
+        setError('회원가입에 실패했습니다. 다시 시도해주세요.');
+      }
     } finally {
       setLoading(false);
     }
   };
 
-  if (user) {
-    return (
-      <div className="max-w-md mx-auto bg-white rounded-lg shadow-md p-6">
-        <div className="text-center">
-          <div className="text-green-600 text-6xl mb-4">✅</div>
-          <h2 className="text-2xl font-bold mb-4">가입 완료!</h2>
-          <div className="text-left space-y-2">
-            <p><strong>이름:</strong> {user.name}</p>
-            <p><strong>이메일:</strong> {user.email}</p>
-            <p><strong>전화번호:</strong> {user.phoneNumber}</p>
-          </div>
-          <p className="text-sm text-gray-600 mt-4">
-            잠시 후 로그인 페이지로 이동합니다...
-          </p>
-        </div>
-      </div>
-    );
-  }
+  // 전화번호 입력 시 숫자만 허용
+  const handlePhoneChange = (e: React.ChangeEvent<HTMLInputElement>) => {
+    const value = e.target.value.replace(/[^0-9]/g, ''); // 숫자만 추출
+    setFormData({...formData, phoneNumber: value});
+  };
 
   return (
-    <div className="max-w-md mx-auto">
-      <div className="bg-white rounded-lg shadow-md p-6">
-        <h2 className="text-2xl font-bold mb-6 text-center">회원 가입</h2>
+    <div className="min-h-screen flex items-center justify-center bg-gray-50 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-md w-full space-y-8">
+        <div>
+          <h2 className="mt-6 text-center text-3xl font-extrabold text-gray-900">
+            🎫 Concert Hub 회원가입
+          </h2>
+          <p className="mt-2 text-center text-sm text-gray-600">
+            이미 계정이 있으신가요?{' '}
+            <Link to="/login" className="font-medium text-blue-600 hover:text-blue-500">
+              로그인
+            </Link>
+          </p>
+        </div>
         
-        <form onSubmit={handleSubmit} className="space-y-4">
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              이름
-            </label>
-            <input
-              type="text"
-              required
-              value={formData.name}
-              onChange={(e) => setFormData({...formData, name: e.target.value})}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="홍길동"
-            />
+        <form className="mt-8 space-y-6" onSubmit={handleSubmit}>
+          <div className="space-y-4">
+            <div>
+              <label htmlFor="name" className="block text-sm font-medium text-gray-700">
+                이름
+              </label>
+              <input
+                id="name"
+                name="name"
+                type="text"
+                required
+                value={formData.name}
+                onChange={(e) => setFormData({...formData, name: e.target.value})}
+                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="홍길동"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="email" className="block text-sm font-medium text-gray-700">
+                이메일
+              </label>
+              <input
+                id="email"
+                name="email"
+                type="email"
+                required
+                value={formData.email}
+                onChange={(e) => setFormData({...formData, email: e.target.value})}
+                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="example@email.com"
+              />
+            </div>
+
+            <div>
+              <label htmlFor="phoneNumber" className="block text-sm font-medium text-gray-700">
+                전화번호
+              </label>
+              <input
+                id="phoneNumber"
+                name="phoneNumber"
+                type="tel"
+                required
+                value={formData.phoneNumber}
+                onChange={handlePhoneChange}
+                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="01012345678"
+                maxLength={11}
+              />
+            </div>
+
+            <div>
+              <label htmlFor="password" className="block text-sm font-medium text-gray-700">
+                비밀번호
+              </label>
+              <input
+                id="password"
+                name="password"
+                type="password"
+                required
+                value={formData.password}
+                onChange={(e) => setFormData({...formData, password: e.target.value})}
+                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="비밀번호를 입력해주세요"
+              />
+              <p className="mt-1 text-xs text-gray-500">
+                8자 이상, 영문+숫자+특수문자(@$!%*?&) 포함
+              </p>
+            </div>
+
+            <div>
+              <label htmlFor="confirmPassword" className="block text-sm font-medium text-gray-700">
+                비밀번호 확인
+              </label>
+              <input
+                id="confirmPassword"
+                name="confirmPassword"
+                type="password"
+                required
+                value={formData.confirmPassword}
+                onChange={(e) => setFormData({...formData, confirmPassword: e.target.value})}
+                className="mt-1 appearance-none relative block w-full px-3 py-2 border border-gray-300 rounded-md placeholder-gray-500 text-gray-900 focus:outline-none focus:ring-blue-500 focus:border-blue-500 focus:z-10 sm:text-sm"
+                placeholder="비밀번호를 다시 입력해주세요"
+              />
+            </div>
           </div>
+
+          {error && (
+            <div className="rounded-md bg-red-50 p-4">
+              <div className="text-center">
+                <h3 className="text-sm font-medium text-red-800">
+                  회원가입 오류
+                </h3>
+                <div className="mt-2 text-sm text-red-700">
+                  {error}
+                </div>
+              </div>
+            </div>
+          )}
 
           <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              이메일
-            </label>
-            <input
-              type="email"
-              required
-              value={formData.email}
-              onChange={(e) => setFormData({...formData, email: e.target.value})}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="example@email.com"
-            />
+            <button
+              type="submit"
+              disabled={loading}
+              className="group relative w-full flex justify-center py-2 px-4 border border-transparent text-sm font-medium rounded-md text-white bg-blue-600 hover:bg-blue-700 focus:outline-none focus:ring-2 focus:ring-offset-2 focus:ring-blue-500 disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              {loading ? (
+                <span className="flex items-center">
+                  <svg className="animate-spin -ml-1 mr-3 h-5 w-5 text-white" xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 24 24">
+                    <circle className="opacity-25" cx="12" cy="12" r="10" stroke="currentColor" strokeWidth="4"></circle>
+                    <path className="opacity-75" fill="currentColor" d="M4 12a8 8 0 018-8V0C5.373 0 0 5.373 0 12h4zm2 5.291A7.962 7.962 0 014 12H0c0 3.042 1.135 5.824 3 7.938l3-2.647z"></path>
+                  </svg>
+                  가입 중...
+                </span>
+              ) : (
+                '가입하기'
+              )}
+            </button>
           </div>
-
-          <div>
-            <label className="block text-sm font-medium text-gray-700 mb-1">
-              전화번호
-            </label>
-            <input
-              type="tel"
-              required
-              pattern="[0-9]{3}-[0-9]{4}-[0-9]{4}"
-              value={formData.phoneNumber}
-              onChange={(e) => setFormData({...formData, phoneNumber: e.target.value})}
-              className="w-full px-3 py-2 border border-gray-300 rounded-md focus:outline-none focus:ring-2 focus:ring-blue-500"
-              placeholder="010-1234-5678"
-            />
-          </div>
-
-          <div className="text-sm text-gray-600 bg-blue-50 p-3 rounded">
-            <p><strong>알림:</strong> 현재 기본 비밀번호는 'password123'으로 설정됩니다.</p>
-            <p>회원가입 후 해당 비밀번호로 로그인해주세요.</p>
-          </div>
-
-          <button
-            type="submit"
-            disabled={loading}
-            className="w-full bg-blue-600 text-white py-2 rounded-md hover:bg-blue-700 disabled:opacity-50"
-          >
-            {loading ? '가입 중...' : '가입하기'}
-          </button>
         </form>
-
-        <p className="mt-4 text-center text-sm text-gray-600">
-          이미 계정이 있으신가요?{' '}
-          <Link to="/login" className="font-medium text-blue-600 hover:text-blue-500">
-            로그인
-          </Link>
-        </p>
       </div>
     </div>
   );

--- a/frontend/src/services/authService.ts
+++ b/frontend/src/services/authService.ts
@@ -1,4 +1,4 @@
-import { LoginRequest, JwtTokens, ApiResponse } from '../types/auth';
+import type { LoginRequest, JwtTokens, ApiResponse } from '../types';
 
 const TOKEN_KEY = 'concert_hub_tokens';
 const API_BASE_URL = 'http://localhost:8080/api';

--- a/frontend/src/types/auth.ts.backup
+++ b/frontend/src/types/auth.ts.backup
@@ -9,12 +9,6 @@ export interface JwtTokens {
   refreshToken: string;
 }
 
-export interface ApiResponse<T> {
-  success: boolean;
-  message: string;
-  data: T;
-}
-
 export interface User {
   id: number;
   name: string;

--- a/frontend/src/types/index.ts
+++ b/frontend/src/types/index.ts
@@ -1,3 +1,21 @@
+// 공통 API 응답 타입
+export interface ApiResponse<T> {
+  success: boolean;
+  message: string;
+  data: T;
+}
+
+// 인증 관련 타입
+export interface LoginRequest {
+  email: string;
+  password: string;
+}
+
+export interface JwtTokens {
+  accessToken: string;
+  refreshToken: string;
+}
+
 // 이벤트 관련 타입
 export interface Event {
   id: number;
@@ -32,6 +50,9 @@ export interface User {
   name: string;
   email: string;
   phoneNumber: string;
+  role?: 'USER' | 'ADMIN';
+  createdAt?: string;
+  updatedAt?: string;
 }
 
 // 예약 관련 타입


### PR DESCRIPTION
# feat(frontend): JWT 기반 로그인/로그아웃 시스템 구현

## 구현 배경

백엔드 JWT 인증 API와 연결하여 프론트엔드 로그인/로그아웃 시스템을 구현했습니다.

## 주요 구현 사항

### 1. 인증 페이지 구현
- **랜딩페이지**: 서비스 소개 및 로그인/회원가입 버튼
- **로그인 페이지**: 이메일/비밀번호 입력, 에러 메시지 표시
- **회원가입 페이지**: 사용자 정보 입력, 비밀번호 확인 기능

### 2. JWT 토큰 관리
```javascript
// authService.ts
class AuthService {
  async login(loginData) {
    const response = await fetch('/api/auth/login', {
      method: 'POST',
      body: JSON.stringify(loginData)
    });
    const result = await response.json();
    this.setTokens(result.data);
  }
  
  setTokens(tokens) {
    localStorage.setItem('concert_hub_tokens', JSON.stringify(tokens));
  }
}
```

### 3. API 클라이언트 연결
```javascript
// client.ts - 모든 API 요청에 토큰 자동 추가
apiClient.interceptors.request.use((config) => {
  const token = authService.getAccessToken();
  if (token) {
    config.headers.Authorization = `Bearer ${token}`;
  }
  return config;
});
```

### 4. 라우트 보호
```jsx
const ProtectedRoute = ({ children }) => {
  const { isAuthenticated } = useAuth();
  return isAuthenticated ? children : <Navigate to="/login" />;
};
```

### 5. 사용자 플로우 개선
- 회원가입 완료 시 자동 로그인 후 `/events`로 이동
- 로그인 성공 시 `/events`로 이동
- 비인증 상태에서 보호된 페이지 접근 시 `/login`으로 리다이렉트

## 기술적 개선

### 전화번호 입력 개선
**문제**: 백엔드에서 `000-0000-0000` 형식 요구로 인한 UX 불편
**해결**: 백엔드 검증을 `10-11자리 숫자`로 변경, 프론트에서 숫자만 입력받도록 수정

```java
// UserCreateRequest.java
@Pattern(regexp = "^\\d{10,11}$", message = "전화번호는 10-11자리 숫자여야 합니다.")
```

## 완료된 기능

- ✅ 로그인/로그아웃 기능
- ✅ 회원가입 기능  
- ✅ JWT 토큰 자동 관리
- ✅ API 요청 시 Authorization 헤더 자동 추가
- ✅ 보호된 라우트 시스템
- ✅ 토큰 만료 시 자동 갱신
- ✅ 에러 처리 및 사용자 안내